### PR TITLE
Allow all child component labels to be hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ TableRepeater::make('social')
     ->columnSpan('full')
 ```
 
-By default Table Repeater will automatically create the table headers from your schema labels. This can be overridden by simply passing an array of your desired headers to the `->headers()` method.
+By default, Table Repeater will automatically create the table headers from your schema labels. This can be overridden by simply passing an array of your desired headers to the `->headers()` method.
 
 ```php
 TableRepeater::make('social')
@@ -45,6 +45,18 @@ TableRepeater::make('social')
         ...
     ])
     ->columnSpan('full')
+```
+
+### Labels
+
+To automatically hide all the labels of the fields in the table use the `->hideLabels()` method.
+
+```php
+TableRepeater::make('social')
+    ->hideLabels()
+    ->schema([
+        ...
+    ])
 ```
 
 ## Themeing

--- a/src/Components/TableRepeater.php
+++ b/src/Components/TableRepeater.php
@@ -11,6 +11,25 @@ class TableRepeater extends Repeater
 
     protected string $view = 'filament-table-repeater::components.repeater-table';
 
+    protected bool | Closure $showLabels = true;
+
+    public function getChildComponents(): array
+    {
+        $components = parent::getChildComponents();
+
+        if ($this->shouldShowLabels()) {
+            return $components;
+        }
+
+        foreach ($components as $component) {
+            if (method_exists($component, 'disableLabel')) {
+                $component->disableLabel();
+            }
+        }
+
+        return $components;
+    }
+
     public function headers(array | Closure $headers): static
     {
         $this->headers = $headers;
@@ -29,5 +48,24 @@ class TableRepeater extends Repeater
         }
 
         return $this->evaluate($this->headers);
+    }
+
+    public function showLabels(bool | Closure $show = true): static
+    {
+        $this->showLabels = $show;
+
+        return $this;
+    }
+
+    public function hideLabels(): static
+    {
+        $this->showLabels = false;
+
+        return $this;
+    }
+
+    protected function shouldShowLabels(): bool
+    {
+        return $this->evaluate($this->showLabels);
     }
 }


### PR DESCRIPTION
This PR introduces `hideLabels()` and `showLabels(bool | Closure)` methods to the TableRepeater class.

This will allow you to hide all the labels at once rather than having to call `disableLabel` on ever field in the table.