### PR TITLE
Fixed key for merged arrays.

### DIFF
--- a/src/Components/TableRepeater.php
+++ b/src/Components/TableRepeater.php
@@ -58,7 +58,7 @@ class TableRepeater extends Repeater
 
             $customHeaders = $this->evaluate($this->headers);
 
-            $mergedHeaders[$field->getId()] = $customHeaders[$key] ?? $field->getLabel();
+            $mergedHeaders[method_exists($field, 'getName') ? $field->getName() : $field->getId()] = $customHeaders[$key] ?? $field->getLabel();
         }
 
         $this->headers = $mergedHeaders;

--- a/src/Components/TableRepeater.php
+++ b/src/Components/TableRepeater.php
@@ -58,7 +58,7 @@ class TableRepeater extends Repeater
 
             $customHeaders = $this->evaluate($this->headers);
 
-            $mergedHeaders[$field->getName()] = $customHeaders[$key] ?? $field->getLabel();
+            $mergedHeaders[$field->getId()] = $customHeaders[$key] ?? $field->getLabel();
         }
 
         $this->headers = $mergedHeaders;


### PR DESCRIPTION
Changed key of merged headers array from `name` to `id` because when a `Tab` field is used in `TableRepeat` (which is really special need but it works) there is no `getName` method.