### PR TITLE
fix: add missing `emptyLabel` closure type

### DIFF
--- a/src/Components/TableRepeater.php
+++ b/src/Components/TableRepeater.php
@@ -14,7 +14,7 @@ class TableRepeater extends Repeater
 
     protected array|Closure $columnWidths = [];
 
-    protected null|string $emptyLabel = null;
+    protected null|string|Closure $emptyLabel = null;
 
     protected bool|Closure $showLabels = true;
 


### PR DESCRIPTION
This PR should fix `$emptyLabel` type.
 Obviously, the `$emptyLabel` attribute should have the same type as `emptyLabel()` setter.