### PR TITLE
Fix: Replace $this->id property with getId() function

### DIFF
--- a/resources/views/components/repeater-table.blade.php
+++ b/resources/views/components/repeater-table.blade.php
@@ -110,7 +110,7 @@
                     @if (count($containers))
                         @foreach ($containers as $uuid => $row)
                             <tr
-                                wire:key="{{ $this->id }}.{{ $row->getStatePath() }}.{{ $field::class }}.item"
+                                wire:key="{{ $this->getId() }}.{{ $row->getStatePath() }}.{{ $field::class }}.item"
                                 x-sortable-item="{{ $uuid }}"
                                 class="filament-table-repeater-row md:divide-x md:rtl:divide-x-reverse md:divide-gray-300 dark:md:divide-gray-700"
                             >


### PR DESCRIPTION
When using the TableRepeater with relationships the following error occurs: 

```
get_class(): Argument #1 ($object) must be of type object, string given
```

Cause: The id property is not accessible anymore. However you can still access it via the `getId()` function. This PR fixes this.

The same change has [happened in the Filament v3 Repeater](https://github.com/filamentphp/filament/blob/aa0527059a2612a2e3913f11cd49cd9a4926ae5c/packages/forms/resources/views/components/repeater.blade.php#L65).