### PR TITLE
Fix Table Repeater for MorphToSelect

### DIFF
--- a/src/Components/TableRepeater.php
+++ b/src/Components/TableRepeater.php
@@ -91,13 +91,12 @@ class TableRepeater extends Repeater
             $key = method_exists($field, 'getName') ? $field->getName() : $field->getId();
 
             $isRequired = false;
-
-            $reflector = new \ReflectionClass($field);
-            if ($reflector->hasProperty('isRequired') && $reflector->getProperty('isRequired')->isPublic() && is_bool($field->isRequired)) {
-                $isRequired = $field->isRequired;
+            
+            if (property_exists($field, 'isRequired') && is_bool($field->isRequired())) {
+                $isRequired = $field->isRequired();
 
                 if (property_exists($field, 'isMarkedAsRequired')) {
-                    $isRequired = $field->isRequired && $field->isMarkedAsRequired;
+                    $isRequired = $field->isRequired() && $field->isMarkedAsRequired;
                 }
             }
 

--- a/src/Components/TableRepeater.php
+++ b/src/Components/TableRepeater.php
@@ -92,7 +92,8 @@ class TableRepeater extends Repeater
 
             $isRequired = false;
 
-            if (property_exists($field, 'isRequired') && is_bool($field->isRequired)) {
+            $reflector = new \ReflectionClass($field);
+            if ($reflector->hasProperty('isRequired') && $reflector->getProperty('isRequired')->isPublic() && is_bool($field->isRequired)) {
                 $isRequired = $field->isRequired;
 
                 if (property_exists($field, 'isMarkedAsRequired')) {


### PR DESCRIPTION
MorphToSelect's `isRequired` field is protected and so the TableRepeater fails when trying to access this property.

This instead uses the public function `isRequired()` to retrieve this value.