### PR TITLE
Update README.md - disableLabel() deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ This field has most of the same functionality of the [Filament Forms Repeater](h
 TableRepeater::make('social')
     ->schema([
         Select::make('platform')
-            ->disableLabel()
+            ->hiddenLabel()
             ->options([
                 'facebook' => 'Facebook',
                 'twitter' => 'Twitter',
                 'instagram' => 'Instagram'
             ]),
         TextInput::make('handle')
-            ->disableLabel(),
+            ->hiddenLabel(),
     ])
     ->columnSpan('full')
 ```


### PR DESCRIPTION
The `disableLabel()` has been deprecated in v3

Reference: [HasLabel Trait](https://github.com/filamentphp/filament/blob/v3.0.0-alpha1/packages/forms/src/Components/Concerns/HasLabel.php)