### PR TITLE
Feature: Enable Scrolling and Strict Width to table

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ TableRepeater::make('social')
     ])
 ```
 
+### Strict Width
+
+Normally, setting a column width in a table adapts it to fit within the remaining 
+table space. If you want precise control and prevent stretching or shrinking, 
+use the `strictWidth()` method to enforce that specific width.
+
+```php
+TableRepeater::make('social')
+    ->strictWidth() // accepts Closure
+```
+
 ### Break Point
 
 Below a specific break point the table will render as a set of panels to 
@@ -124,6 +135,18 @@ can be overridden with the `breakPoint()` method.
 ```php
 TableRepeater::make('social')
     ->breakPoint('sm') // accepts Tailwind CSS screen sizes
+```
+
+### Scrolling
+
+For tables exceeding available space, enable both scrolling and fixed column widths. 
+Use `scrollable()` to activate horizontal scrolling, and complement it with `strictWidth()` 
+to prevent unwanted stretching or shrinking of columns.
+
+```php
+TableRepeater::make('social')
+    ->scrollable() // accepts Closure
+    ->strictWidth() // accepts Closure
 ```
 
 ## Changelog

--- a/resources/views/components/table-repeater.blade.php
+++ b/resources/views/components/table-repeater.blade.php
@@ -50,7 +50,7 @@
                 '2xl' => 'break-point-2xl',
                 default => 'break-point-md',
             },
-            'overflow-auto' => $scrollable
+            'overflow-auto' => $getScrollable()
         ]) }}
     >
         @if (count($containers) || $emptyLabel !== false)
@@ -81,7 +81,7 @@
                                         }
                                     ])
                                     @if ($header['width'])
-                                        style="{{$strictWidth? 'min-width':'width'}}: {{ $header['width'] }}"
+                                        style="{{$getStrictWidth()? 'min-width':'width'}}: {{ $header['width'] }}"
                                     @endif
                                 >
                                     {{ $header['label'] }}
@@ -155,7 +155,7 @@
                                                     $columnWidths &&
                                                     isset($columnWidths[$cellKey])
                                                 )
-                                                    style="{{$strictWidth? 'min-width':'width'}}: {{ $columnWidths[$cellKey] }}"
+                                                    style="{{$getStrictWidth()? 'min-width':'width'}}: {{ $columnWidths[$cellKey] }}"
                                                 @endif
                                             >
                                                 {{ $cell }}

--- a/resources/views/components/table-repeater.blade.php
+++ b/resources/views/components/table-repeater.blade.php
@@ -155,7 +155,7 @@
                                                     $columnWidths &&
                                                     isset($columnWidths[$cellKey])
                                                 )
-                                                    style="width: {{ $columnWidths[$cellKey] }}"
+                                                    style="{{$strictWidth? 'min-width':'width'}}: {{ $columnWidths[$cellKey] }}"
                                                 @endif
                                             >
                                                 {{ $cell }}

--- a/resources/views/components/table-repeater.blade.php
+++ b/resources/views/components/table-repeater.blade.php
@@ -81,7 +81,7 @@
                                         }
                                     ])
                                     @if ($header['width'])
-                                        style="{{$strict_width? 'min-width':'width'}}: {{ $header['width'] }}"
+                                        style="{{$strictWidth? 'min-width':'width'}}: {{ $header['width'] }}"
                                     @endif
                                 >
                                     {{ $header['label'] }}

--- a/resources/views/components/table-repeater.blade.php
+++ b/resources/views/components/table-repeater.blade.php
@@ -50,7 +50,7 @@
                 '2xl' => 'break-point-2xl',
                 default => 'break-point-md',
             },
-            'overflow-auto' => $getScrollable()
+            'overflow-auto' => $shouldBeScrollable()
         ]) }}
     >
         @if (count($containers) || $emptyLabel !== false)
@@ -81,7 +81,7 @@
                                         }
                                     ])
                                     @if ($header['width'])
-                                        style="{{$getStrictWidth()? 'min-width':'width'}}: {{ $header['width'] }}"
+                                        style="{{$shouldStrictWidth()? 'min-width':'width'}}: {{ $header['width'] }}"
                                     @endif
                                 >
                                     {{ $header['label'] }}
@@ -155,7 +155,7 @@
                                                     $columnWidths &&
                                                     isset($columnWidths[$cellKey])
                                                 )
-                                                    style="{{$getStrictWidth()? 'min-width':'width'}}: {{ $columnWidths[$cellKey] }}"
+                                                    style="{{$shouldStrictWidth()? 'min-width':'width'}}: {{ $columnWidths[$cellKey] }}"
                                                 @endif
                                             >
                                                 {{ $cell }}

--- a/resources/views/components/table-repeater.blade.php
+++ b/resources/views/components/table-repeater.blade.php
@@ -49,7 +49,8 @@
                 'xl' => 'break-point-xl',
                 '2xl' => 'break-point-2xl',
                 default => 'break-point-md',
-            }
+            },
+            'overflow-auto' => $scrollable
         ]) }}
     >
         @if (count($containers) || $emptyLabel !== false)
@@ -80,7 +81,7 @@
                                         }
                                     ])
                                     @if ($header['width'])
-                                        style="width: {{ $header['width'] }}"
+                                        style="{{$strict_width? 'min-width':'width'}}: {{ $header['width'] }}"
                                     @endif
                                 >
                                     {{ $header['label'] }}

--- a/src/Components/TableRepeater.php
+++ b/src/Components/TableRepeater.php
@@ -34,13 +34,13 @@ class TableRepeater extends Repeater
         return $this;
     }
 
-    public function scrollable(bool $scrollable = true): static
+    public function scrollable(bool|string|Closure $scrollable = true): static
     {
         $this->scrollable = $scrollable;
 
         return $this;
     }
-    public function strictWidth(bool $strictWidth = true): static
+    public function strictWidth(bool|string|Closure $strictWidth = true): static
     {
         $this->strictWidth = $strictWidth;
 
@@ -71,6 +71,15 @@ class TableRepeater extends Repeater
     public function getBreakPoint(): string
     {
         return $this->breakPoint;
+    }
+
+    public function getStrictWidth(): string
+    {
+        return $this->evaluate($this->strictWidth);
+    }
+    public function getScrollable(): string
+    {
+        return $this->evaluate($this->scrollable);
     }
 
     public function getColumnWidths(): array

--- a/src/Components/TableRepeater.php
+++ b/src/Components/TableRepeater.php
@@ -40,6 +40,7 @@ class TableRepeater extends Repeater
 
         return $this;
     }
+
     public function strictWidth(bool|string|Closure $strictWidth = true): static
     {
         $this->strictWidth = $strictWidth;

--- a/src/Components/TableRepeater.php
+++ b/src/Components/TableRepeater.php
@@ -67,16 +67,15 @@ class TableRepeater extends Repeater
 
         return $this;
     }
-
     public function getBreakPoint(): string
     {
         return $this->breakPoint;
     }
-
     public function getStrictWidth(): string
     {
         return $this->evaluate($this->strictWidth);
     }
+
     public function getScrollable(): string
     {
         return $this->evaluate($this->scrollable);

--- a/src/Components/TableRepeater.php
+++ b/src/Components/TableRepeater.php
@@ -72,12 +72,12 @@ class TableRepeater extends Repeater
     {
         return $this->breakPoint;
     }
-    public function getStrictWidth(): string
+    public function shouldStrictWidth(): bool
     {
         return $this->evaluate($this->strictWidth);
     }
 
-    public function getScrollable(): string
+    public function shouldBeScrollable(): bool
     {
         return $this->evaluate($this->scrollable);
     }

--- a/src/Components/TableRepeater.php
+++ b/src/Components/TableRepeater.php
@@ -11,6 +11,10 @@ class TableRepeater extends Repeater
 {
     protected string $breakPoint = 'md';
 
+    protected bool $strictWidth = false;
+
+    protected bool $scrollable = false;
+
     protected array|Closure $columnWidths = [];
 
     protected null|bool|string|Closure $emptyLabel = null;
@@ -26,6 +30,19 @@ class TableRepeater extends Repeater
     public function breakPoint(string $breakPoint = 'md'): static
     {
         $this->breakPoint = $breakPoint;
+
+        return $this;
+    }
+
+    public function scrollable(bool $scrollable = true): static
+    {
+        $this->scrollable = $scrollable;
+
+        return $this;
+    }
+    public function strictWidth(bool $strictWidth = true): static
+    {
+        $this->strictWidth = $strictWidth;
 
         return $this;
     }


### PR DESCRIPTION
I have faced a condition where I had many columns, static and dynamic ones. As shown below:
![Screenshot from 2024-01-29 11-38-58](https://github.com/awcodes/filament-table-repeater/assets/35528749/d4f0834d-48f8-4adf-a882-e667bfb994aa)

Added the features to enable scrolling and strictWidth to replace (th,td) width with min-wdith to enforce the columnWidths as shown below:
![Screenshot from 2024-01-29 11-22-29](https://github.com/awcodes/filament-table-repeater/assets/35528749/3f3a1b1c-45e7-4ea8-b9d8-055b1ef702ab)
