### PR TITLE
getView to getDefaultView

### DIFF
--- a/src/Components/TableRepeater.php
+++ b/src/Components/TableRepeater.php
@@ -167,7 +167,7 @@ class TableRepeater extends Repeater
         return $this;
     }
 
-    public function getView(): string
+    public function getDefaultView(): string
     {
         return 'filament-table-repeater::components.table-repeater';
     }


### PR DESCRIPTION
By changing getView() to getDefaultView() in TableRepeater.php it will allow users to override the default view if required which is not currently possible. 

```
      TableRepeater::make('name')
                ->schema([])
                ->view('filament.plugins.components.table-repeater')
```