### PR TITLE
Fix extra item actions

### DIFF
--- a/resources/views/components/table-repeater.blade.php
+++ b/resources/views/components/table-repeater.blade.php
@@ -26,6 +26,13 @@
 
     $statePath = $getStatePath();
 
+    foreach ($containers as $uuid => $row) {
+        $visibleExtraItemActions = array_filter(
+            $extraItemActions,
+            fn (Action $action): bool => $action(['item' => $uuid])->isVisible(),
+        );
+    }
+
     foreach ($extraActions as $extraAction) {
         $visibleExtraActions = array_filter(
             $extraActions,
@@ -100,12 +107,6 @@
                     >
                     @if (count($containers))
                         @foreach ($containers as $uuid => $row)
-                            @php
-                                $visibleExtraItemActions = array_filter(
-                                    $extraItemActions,
-                                    fn (Action $action): bool => $action(['item' => $uuid])->isVisible(),
-                                );
-                            @endphp
                             <tr
                                 wire:key="{{ $this->getId() }}.{{ $row->getStatePath() }}.{{ $field::class }}.item"
                                 x-sortable-item="{{ $uuid }}"

--- a/resources/views/components/table-repeater.blade.php
+++ b/resources/views/components/table-repeater.blade.php
@@ -26,13 +26,6 @@
 
     $statePath = $getStatePath();
 
-    foreach ($containers as $uuid => $row) {
-        $visibleExtraItemActions = array_filter(
-            $extraItemActions,
-            fn (Action $action): bool => $action(['item' => $uuid])->isVisible(),
-        );
-    }
-
     foreach ($extraActions as $extraAction) {
         $visibleExtraActions = array_filter(
             $extraActions,
@@ -107,6 +100,12 @@
                     >
                     @if (count($containers))
                         @foreach ($containers as $uuid => $row)
+                            @php
+                                $visibleExtraItemActions = array_filter(
+                                    $extraItemActions,
+                                    fn (Action $action): bool => $action(['item' => $uuid])->isVisible(),
+                                );
+                            @endphp
                             <tr
                                 wire:key="{{ $this->getId() }}.{{ $row->getStatePath() }}.{{ $field::class }}.item"
                                 x-sortable-item="{{ $uuid }}"


### PR DESCRIPTION
Hey,

Not sure If I am doing something wrong or it is a bug. It's about the icon being visible or not (the hidden function)
I have this code in my OrderResource:
```php
->extraItemActions([
    Action::make('openProduct')
        ->tooltip('Open product')
        ->icon('heroicon-m-arrow-top-right-on-square')
        ->url(function (array $arguments, Repeater $component): ?string {
            $itemData = $component->getRawItemState($arguments['item']);

            $product = Product::find($itemData['product_id']);

            if (! $product) {
                return null;
            }

            return ProductResource::getUrl('edit', ['record' => $product]);
        }, shouldOpenInNewTab: true)
        ->hidden(function (array $arguments, Repeater $component): bool {
            return blank($component->getRawItemState($arguments['item'])['product_id']);

        })
])
```
When I add the first item to the repeater the hidden function returns true show it shows the link. However when adding the second item, the hidden function returns false.
Now the expected behaviour is that by the first item you show still see the link but not by the second one. 
In my code both rows don't show the links. 
Not sure if this is a bug or not...

Here is a more visual representation of the issue

https://github.com/awcodes/filament-table-repeater/assets/176772/74437797-e55d-4a5e-b456-0763b52467aa

