### PR TITLE
Prevent header errors in most conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ use Awcodes\TableRepeater\Components\TableRepeater;
 use Awcodes\TableRepeater\Header;
 
 TableRepeater::make('users')
-     ->headers([
+     ->headers([ // optional
         Header::make('name')->width('150px'),
     ])
     ->schema([
@@ -58,7 +58,7 @@ TableRepeater::make('users')
 
 ### Headers
 
-To add headers use the `headers()` method. and pass in an array of `Header` components.
+To have more control over the headers, use the `headers()` method. and pass in an array of `Header` components.
 
 ```php
 use Awcodes\TableRepeater\Header;
@@ -101,7 +101,7 @@ Header::make('name')
 
 #### Hiding the header
 
-Even if you do not want to show a header, you should still add them to be compliant with accessibility standards. You can hide the header though with the `renderHeader()` method.
+If you do not want to show the headers, you can override them though `renderHeader()` method.
 
 ```php
 TableRepeater::make('users')

--- a/src/Components/Concerns/HasHeader.php
+++ b/src/Components/Concerns/HasHeader.php
@@ -30,16 +30,15 @@ trait HasHeader
         $headers = $this->evaluate($this->headers) ?? [];
         $fields = $this->childComponents;
 
-        if (count($headers) < count($fields)) {
-            foreach($fields as $field) {
-                $headers[] = Header::make($field->getLabel());
+        foreach ($fields as $index => $field) {
+            if (!isset($headers[$index]) || !is_string($headers[$index])) {
+                $headers[$index] = Header::make($field->getLabel());
+            } else {
+                $headers[$index] = Header::make($headers[$index]);
             }
         }
 
-        return array_map(
-            fn ($header) => $header instanceof Header ? $header : Header::make($header),
-            $headers,
-        );
+        return $headers;
     }
 
     public function shouldRenderHeader(): bool

--- a/src/Components/Concerns/HasHeader.php
+++ b/src/Components/Concerns/HasHeader.php
@@ -2,6 +2,7 @@
 
 namespace Awcodes\TableRepeater\Components\Concerns;
 
+use Awcodes\TableRepeater\Header;
 use Closure;
 
 trait HasHeader
@@ -26,7 +27,19 @@ trait HasHeader
 
     public function getHeaders(): array
     {
-        return $this->evaluate($this->headers) ?? [];
+        $headers = $this->evaluate($this->headers) ?? [];
+        $fields = $this->childComponents;
+
+        if (count($headers) < count($fields)) {
+            foreach($fields as $field) {
+                $headers[] = Header::make($field->getLabel());
+            }
+        }
+
+        return array_map(
+            fn ($header) => $header instanceof Header ? $header : Header::make($header),
+            $headers,
+        );
     }
 
     public function shouldRenderHeader(): bool

--- a/src/Components/Concerns/HasHeader.php
+++ b/src/Components/Concerns/HasHeader.php
@@ -28,14 +28,13 @@ trait HasHeader
     public function getHeaders(): array
     {
         $headers = $this->evaluate($this->headers) ?? [];
-        $fields = $this->childComponents;
 
-        foreach ($fields as $index => $field) {
-            if (!isset($headers[$index]) || !is_string($headers[$index])) {
+        foreach ($this->getChildComponents() as $index => $field) {
+            if (!isset($headers[$index])) {
                 $headers[$index] = Header::make($field->getLabel());
-            } else {
-                $headers[$index] = Header::make($headers[$index]);
-            }
+            } elseif (!($headers[$index] instanceof Header)) {
+                $headers[$index] = Header::make($headers[$index] ?? $field->getLabel());
+            };
         }
 
         return $headers;


### PR DESCRIPTION
This fix is intended to address some inconveniences that cause errors:
- The use of `headers()` is now optional.
- We can define only what we need (fill the array with `null`s to adjust the column position).
- We can define as array of strings to change the labels.
- This is not a breaking change and has been manually tested.

```php
TableRepeater::make('childrens')
    ->headers([
        null,
        Header::make('Agent Code')->align('center'),
        'Registered at',
    ])
    ->schema([
        TextInput::make('name'),
        TextInput::make('code'),
        TextInput::make('created_at'),
        TextInput::make('updated_at'),
    ])
```