### PR TITLE
Vertical align top columns

### DIFF
--- a/resources/css/plugin.css
+++ b/resources/css/plugin.css
@@ -1,4 +1,4 @@
-.table-repeater-column {
+.table-repeater-column.text-start {
     vertical-align: top;
 }
 

--- a/resources/css/plugin.css
+++ b/resources/css/plugin.css
@@ -1,3 +1,7 @@
+.table-repeater-column {
+    vertical-align: top;
+}
+
 .table-repeater-component .choices input {
     min-width: 100% !important;
 }


### PR DESCRIPTION
Add the following styles to .table-repeater-column class in order to properly align fields to the top whenever other column fields have validation error messages:

.table-repeater-column.text-start {
    vertical-align: top;
}

From:
![image](https://github.com/user-attachments/assets/91d84e00-8de9-44aa-a4e6-e6e75c36e89b)

To:
![image](https://github.com/user-attachments/assets/215b8f26-a1e4-4099-b0e2-892d1a2b6add)


